### PR TITLE
Add Web3.NE Meetup group to Meetups data json

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "Web3.NE",
+    "emoji": ":us:",
+    "location": "Omaha",
+    "link": "https://www.meetup.com/web3-ne/"
+  },
+  {
     "title": "ETHTbilisi",
     "emoji": ":ge:",
     "location": "Georgia",


### PR DESCRIPTION
I added the needed json data for my meetup group to show on the ethereum.org meetup page, so more people can find us and connect!

